### PR TITLE
Blacklisting attributes per lang

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -1,6 +1,26 @@
 package main
 
-var attributeBlacklist = map[string]struct{}{
-	"Names":            struct{}{},
-	"Prop_ReturnValue": struct{}{},
+var globalAttributeBlacklist = map[string]struct{}{
+	"Names": struct{}{},
+}
+
+var languageAttributeBlacklist = map[string]map[string]struct{}{
+	"cpp": {
+		"Prop_ReturnValue": struct{}{},
+	},
+	"go": {
+		// "Comments": struct{}{} https://github.com/bblfsh/go-driver/issues/56
+		"Imports": struct{}{},
+	},
+}
+
+func isAttributeBlacklisted(attr string, lang string) bool {
+	if _, exists := globalAttributeBlacklist[attr]; exists {
+		return true
+	} else if attributeBlacklist, exists := languageAttributeBlacklist[lang]; exists {
+		if _, exists := attributeBlacklist[attr]; exists {
+			return true
+		}
+	}
+	return false
 }

--- a/uast2clickhouse.go
+++ b/uast2clickhouse.go
@@ -210,7 +210,7 @@ func emitRecords(repo, file string, tree nodes.Node, emitter chan record) {
 			case nodes.KindObject:
 				if n, ok := node.(nodes.ExternalObject); ok {
 					for _, k := range n.Keys() {
-						if _, exists := attributeBlacklist[k]; !exists {
+						if !isAttributeBlacklisted(k, lang) {
 							v, _ := n.ValueAt(k)
 							queue = append(queue, walkTrace{v, path, k, discardedTypes, ps})
 						}


### PR DESCRIPTION
As discussed in Slack, we blacklist per lang. This causes duplication of Names, not sure whether I should put common attributes separately or not. I also added the deduplication of imports for Go, which halves the number of import nodes.